### PR TITLE
Header keyword modifications for MAST HLSPs

### DIFF
--- a/lightcurve/lightcurve.py
+++ b/lightcurve/lightcurve.py
@@ -513,6 +513,7 @@ def prepare_header(filename, filelist):
                 ra_targ = hdu[0].header['ra_targ']
                 dec_targ = hdu[0].header['dec_targ']
                 equinox = hdu[0].header['equinox']
+                targname = hdu[0].header['targname']
                 tardescr = hdu[0].header.get('TARDESCR', '')
                 tardesc2 = hdu[0].header.get('TARDESC2', '')
 
@@ -530,12 +531,14 @@ def prepare_header(filename, filelist):
         hdu[0].header['RA_TARG'] = ra_targ
         hdu[0].header['DEC_TARG'] = dec_targ
         hdu[0].header['EQUINOX'] = equinox
+        hdu[0].header['TARGNAME'] = targname
         hdu[0].header['TARDESCR'] = tardescr
         hdu[0].header['TARDESC2'] = tardesc2
+        hdu[0].header['EXTNAME'] = 'PRIMARY'
+        hdu[1].header['EXTNAME'] = 'LIGHTCURVE'
 
         uniq, value = is_uniq(telescop)
         hdu[0].header['telescop'] = value
-
 
         uniq, value = is_uniq(instrume)
         hdu[0].header['instrume'] = value


### PR DESCRIPTION
@justincely [This webpage](https://archive.stsci.edu/hlsp/hlsp_guidelines_timeseries.html#Required) page gives the required header keywords for time-series HLSPs.  Looking through the headers of composite lightcurves, I noticed two header keywords that are required but were missing:

```
TARGNAME
EXTNAME
```

This pull request adds those keywords in, though I noticed that the `keep_headers` argument is `False` when `prepare_header` is called by the `composite` method.  So I'm not sure if adding these keywords is just a matter of turning that on or not.